### PR TITLE
Link supplier documents to main documents

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,7 +51,7 @@
         "jest": "^27.5.1",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.1.1",
-        "typescript": "^5.4.5"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -19916,9 +19916,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,7 @@
     "jest": "^27.5.1",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.1.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.9.2"
   },
   "overrides": {},
   "proxy": ""

--- a/frontend/src/components/Suppliers/SupplierDocuments.tsx
+++ b/frontend/src/components/Suppliers/SupplierDocuments.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Box, Button, Chip, LinearProgress, Paper, Stack, Typography } from '@mui/material';
+import { OpenInNew, Refresh } from '@mui/icons-material';
+import { AppDispatch, RootState } from '../../store';
+import { fetchDocuments, setFilters, setPagination } from '../../store/slices/documentSlice';
+import SmartDataTable, { TableColumn, TableAction } from '../Tables/SmartDataTable';
+import { useNavigate } from 'react-router-dom';
+
+const SupplierDocuments: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const { documents, loading } = useSelector((state: RootState) => state.documents);
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (initialized) return;
+    setInitialized(true);
+    dispatch(setFilters({ category: 'supplier' }));
+    dispatch(setPagination({ page: 1 }));
+    dispatch(fetchDocuments({ page: 1, size: 10, category: 'supplier' }));
+  }, [dispatch, initialized]);
+
+  const columns: TableColumn[] = useMemo(() => [
+    { id: 'document_number', label: 'Number', sortable: true },
+    { id: 'title', label: 'Title', sortable: true, searchable: true },
+    { id: 'document_type', label: 'Type', sortable: true, format: (v) => (typeof v === 'string' ? v.replace('_', ' ') : v) },
+    { id: 'status', label: 'Status', sortable: true, type: 'status', format: (v) => <Chip size="small" label={(v || '').replace('_', ' ')} /> },
+    { id: 'version', label: 'Version', sortable: true },
+    { id: 'created_at', label: 'Created', sortable: true },
+  ], []);
+
+  const actions: TableAction[] = useMemo(() => [
+    {
+      id: 'open-docs',
+      label: 'Open in Documents',
+      icon: <OpenInNew fontSize="small" />,
+      onClick: () => navigate('/documents?category=supplier'),
+    },
+  ], [navigate]);
+
+  const handleRefresh = () => {
+    dispatch(fetchDocuments({ page: 1, size: 10, category: 'supplier' }));
+  };
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="h6">Supplier Documents</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<OpenInNew />}
+            onClick={() => navigate('/documents?category=supplier')}
+          >
+            Open in Documents
+          </Button>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<Refresh />}
+            onClick={handleRefresh}
+          >
+            Refresh
+          </Button>
+        </Stack>
+      </Box>
+      <Paper>
+        {loading && <LinearProgress />}
+        <SmartDataTable
+          title="Supplier Documents"
+          columns={columns}
+          data={documents}
+          actions={actions}
+          enableInsights={false}
+          enableExport={false}
+          enableColumnCustomization={false}
+          loading={loading}
+        />
+      </Paper>
+    </Box>
+  );
+};
+
+export default SupplierDocuments;
+

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -65,7 +65,7 @@ import {
   Clear,
   Compare,
 } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { AppDispatch, RootState } from '../store';
 import {
   fetchDocuments,
@@ -144,6 +144,7 @@ const Documents: React.FC = () => {
   const [distributionUsers, setDistributionUsers] = useState<any[]>([]);
   const [selectedDistributionUserIds, setSelectedDistributionUserIds] = useState<number[]>([]);
   const [searchText, setSearchText] = useState<string>(filters?.search || '');
+  const location = useLocation();
 
   // Role-based permissions
   const canCreateDocuments = hasRole(currentUser, 'QA Manager') || 
@@ -167,6 +168,30 @@ const Documents: React.FC = () => {
     loadStats();
     dispatch(fetchPendingApprovals());
   }, [pagination.page, filters]);
+
+  // Initialize filters from query params once
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const category = params.get('category');
+    const status = params.get('status');
+    const document_type = params.get('type') || params.get('document_type');
+    const department = params.get('department');
+    const search = params.get('search');
+
+    const nextFilters: any = {};
+    if (category) nextFilters.category = category;
+    if (status) nextFilters.status = status;
+    if (document_type) nextFilters.document_type = document_type;
+    if (department) nextFilters.department = department;
+    if (search) nextFilters.search = search;
+
+    if (Object.keys(nextFilters).length > 0) {
+      dispatch(setFilters(nextFilters));
+      if (search) setSearchText(search);
+      dispatch(setPagination({ page: 1 }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Debounce search to reduce churn and make UX fluid
   useEffect(() => {

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -34,6 +34,7 @@ import SupplierDashboard from '../components/Suppliers/SupplierDashboard';
 import SupplierList from '../components/Suppliers/SupplierList';
 import MaterialList from '../components/Materials/MaterialList';
 import SupplierForm from '../components/Suppliers/SupplierForm';
+import SupplierDocuments from '../components/Suppliers/SupplierDocuments';
 import MaterialForm from '../components/Materials/MaterialForm';
 import { Supplier, Material } from '../types/supplier';
 import { useLocation } from 'react-router-dom';
@@ -194,12 +195,7 @@ const Suppliers: React.FC = () => {
       case 5:
         return (
           <Box p={3}>
-            <Typography variant="h6" gutterBottom>
-              Documents
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Document management component will be implemented here.
-            </Typography>
+            <SupplierDocuments />
           </Box>
         );
       default:

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -717,6 +717,9 @@ export const haccpAPI = {
 
   // Verification Logs
   createVerificationLog: async (ccpId: number, logData: any) => {
+    const response: AxiosResponse = await api.post(`/haccp/ccps/${ccpId}/verification-logs`, logData);
+    return response.data;
+  },
   getVerificationLogs: async (ccpId: number) => {
     const response: AxiosResponse = await api.get(`/haccp/ccps/${ccpId}/verification-logs`);
     return response.data;


### PR DESCRIPTION
Add a supplier-specific documents view in the Suppliers module that links to the main Documents module with pre-applied supplier filters.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee98a92c-a138-4a80-b1e3-0b59ed2fab5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee98a92c-a138-4a80-b1e3-0b59ed2fab5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

