### PR TITLE
Fix inactive next button in suppliers form

### DIFF
--- a/frontend/src/components/Materials/MaterialForm.tsx
+++ b/frontend/src/components/Materials/MaterialForm.tsx
@@ -1005,14 +1005,14 @@ const MaterialForm: React.FC<MaterialFormProps> = ({
   const canProceedToNext = () => {
     switch (activeStep) {
       case 0:
-        return formik.values.material_code && 
-               formik.values.name && 
-               formik.values.category && 
-               formik.values.supplier_id &&
-               formik.values.storage_conditions;
+        return formik.values.material_code &&
+               formik.values.name &&
+               formik.values.category &&
+               formik.values.supplier_id;
       case 1:
-      case 2:
         return true;
+      case 2:
+        return !!formik.values.storage_conditions;
       default:
         return false;
     }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -742,14 +742,10 @@ export const haccpAPI = {
     return response.data;
   },
 
-  // Utility to fetch most recent NC for a CCP and batch (placeholder)
+  // Utility to fetch most recent NC for a CCP and batch
   getRecentNonConformance: async (ccpId: number, batchNumber: string) => {
-    try {
-      const response: AxiosResponse = await api.get(`/haccp/ccps/${ccpId}/nonconformance/recent`, { params: { batch_number: batchNumber } });
-      return response.data ? { data: response.data } : { data: { found: false } };
-    } catch (err) {
-      return { data: { found: false } } as any;
-    }
+    const response: AxiosResponse = await api.get(`/nonconformance/recent`, { params: { ccp_id: ccpId, batch_number: batchNumber } });
+    return response.data;
   },
 
   getFlowchartData: async (productId: number) => {
@@ -785,11 +781,7 @@ export const haccpAPI = {
     return response.data;
   },
 
-  // Convenience: fetch most recent NC for a CCP and batch
-  getRecentNonConformance: async (ccpId: number, batchNumber: string) => {
-    const response: AxiosResponse = await api.get(`/nonconformance/recent`, { params: { ccp_id: ccpId, batch_number: batchNumber } });
-    return response.data;
-  },
+  // duplicate removed above
 };
 
 // PRP API


### PR DESCRIPTION
Realign material form wizard's "Next" button validation to enforce `storage_conditions` on step 2 instead of step 0, and remove a duplicate API method.

---
<a href="https://cursor.com/background-agent?bcId=bc-27cc9f4f-923d-41bb-92a6-46f88d3eb72c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27cc9f4f-923d-41bb-92a6-46f88d3eb72c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

