### PR TITLE
Always display HACCP logs

### DIFF
--- a/frontend/src/pages/HACCPProductDetail.tsx
+++ b/frontend/src/pages/HACCPProductDetail.tsx
@@ -312,6 +312,26 @@ const HACCPProductDetail: React.FC = () => {
     return () => { active = false; clearTimeout(t); };
   }, [batchOpen, batchSearch]);
 
+  // Fetch existing monitoring logs whenever a CCP is selected
+  useEffect(() => {
+    let active = true;
+    const fetchLogs = async () => {
+      const ccpIdStr = monitoringForm.ccp_id || '';
+      if (!ccpIdStr) { if (active) setMonitoringLogs([]); return; }
+      try {
+        const api = (await import('../services/api')).api;
+        const resp = await api.get(`/haccp/ccps/${Number(ccpIdStr)}/monitoring-logs`);
+        const logsJson = resp.data;
+        const items = logsJson?.data?.items || logsJson?.items || [];
+        if (active) setMonitoringLogs(items);
+      } catch {
+        if (active) setMonitoringLogs([]);
+      }
+    };
+    fetchLogs();
+    return () => { active = false; };
+  }, [monitoringForm.ccp_id]);
+
   const [riskConfigDialogOpen, setRiskConfigDialogOpen] = useState(false);
   const [riskConfigForm, setRiskConfigForm] = useState({
     calculation_method: 'multiplication',


### PR DESCRIPTION
Display HACCP monitoring logs on initial CCP selection to prevent the table from appearing empty before form submission.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e60d68c-fb78-48e7-9222-bd31a4b19447">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e60d68c-fb78-48e7-9222-bd31a4b19447">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

