### PR TITLE
Show user names instead of IDs in processes

### DIFF
--- a/frontend/src/pages/Production.tsx
+++ b/frontend/src/pages/Production.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -91,6 +91,18 @@ const ProductionPage: React.FC = () => {
     tolerance_max: undefined,
     notes: '',
   });
+
+  // Map user id to display name (full_name preferred, fallback to username)
+  const userDisplayNameById = useMemo(() => {
+    const map: Record<number, string> = {};
+    users.forEach((u: any) => {
+      const display = u?.full_name || u?.username || `User #${u?.id}`;
+      if (typeof u?.id === 'number') {
+        map[u.id] = display;
+      }
+    });
+    return map;
+  }, [users]);
 
   useEffect(() => {
     loadData();
@@ -396,7 +408,7 @@ const ProductionPage: React.FC = () => {
                       <TableCell>
                         {new Date(process.start_time).toLocaleString()}
                       </TableCell>
-                      <TableCell>{process.operator_id || '—'}</TableCell>
+                      <TableCell>{process.operator_id ? (userDisplayNameById[process.operator_id] || process.operator_id) : '—'}</TableCell>
                       <TableCell>
                         <Stack direction="row" spacing={1}>
                           <Tooltip title="View Details">

--- a/frontend/src/pages/ProductionProcessDetail.tsx
+++ b/frontend/src/pages/ProductionProcessDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   Box,
@@ -86,6 +86,17 @@ const ProductionProcessDetail: React.FC = () => {
   const [stageGates, setStageGates] = useState<{ key: string; esign?: boolean }[] | null>(null);
   const [stagesWithMonitoring, setStagesWithMonitoring] = useState<{ stages: any[] } | null>(null);
   const [reqAssessments, setReqAssessments] = useState<any[] | null>(null);
+
+  // Map user id to display name for operator rendering
+  const userDisplayNameById = useMemo(() => {
+    const map: Record<number, string> = {};
+    users.forEach((u: any) => {
+      if (typeof u?.id === 'number') {
+        map[u.id] = u?.full_name || u?.username || `User #${u.id}`;
+      }
+    });
+    return map;
+  }, [users]);
 
   const loadDetails = useCallback(async () => {
     if (!id) return;
@@ -561,7 +572,7 @@ const ProductionProcessDetail: React.FC = () => {
                 </ListItem>
                 <ListItem>
                   <ListItemText 
-                    primary={`Operator: ${processDetails?.operator_id || '—'}`} 
+                    primary={`Operator: ${processDetails?.operator_id ? (userDisplayNameById[processDetails.operator_id] || processDetails.operator_id) : '—'}`} 
                     secondary={`Start: ${processDetails?.start_time ? new Date(processDetails.start_time).toLocaleString() : '—'}`} 
                   />
                 </ListItem>

--- a/frontend/src/pages/ProductionProcessDetail.tsx
+++ b/frontend/src/pages/ProductionProcessDetail.tsx
@@ -798,7 +798,7 @@ const ProductionProcessDetail: React.FC = () => {
                         <TableRow key={r.id}>
                           <TableCell>{new Date(r.created_at).toLocaleString()}</TableCell>
                           <TableCell><Chip label={r.action} size="small" /></TableCell>
-                          <TableCell>{r.user_id ?? '—'}</TableCell>
+                          <TableCell>{r.user_id ? (userDisplayNameById[r.user_id] || r.user_id) : '—'}</TableCell>
                           <TableCell><pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{JSON.stringify(r.details || {}, null, 2)}</pre></TableCell>
                         </TableRow>
                       ))}


### PR DESCRIPTION
Display operator names instead of user IDs in the productions module's processes table.

---
<a href="https://cursor.com/background-agent?bcId=bc-384acf1c-6bdb-4916-b77f-250518c28cf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-384acf1c-6bdb-4916-b77f-250518c28cf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

